### PR TITLE
Fixed build under MSVC

### DIFF
--- a/src/FreeImage/Source/OpenEXR/IlmImf/ImfAttribute.cpp
+++ b/src/FreeImage/Source/OpenEXR/IlmImf/ImfAttribute.cpp
@@ -61,7 +61,7 @@ Attribute::~Attribute () {}
 
 namespace {
 
-struct NameCompare: std::binary_function <const char *, const char *, bool>
+struct NameCompare
 {
     bool
     operator () (const char *x, const char *y) const


### PR DESCRIPTION
This fixes build error `Error C2039 'binary_function': is not a member of 'std' ` in FreeImage/OpenEXR under latest Visual Studio 2022 
See https://learn.microsoft.com/en-us/answers/questions/1348183/std-binary-function-is-missing-in-msvc-14-37-32822

I tried upgrading FreeImage to latest but it has the same issue (July 31st, 2018: FreeImage 3.18.0 released).
Note ours is pretty old (March 17th, 2012: FreeImage 3.15.3 released).

I ended up just deleting the offending code because it turned out to be deadcode (a `std::map` compare func has nothing to do with `binary_function`).